### PR TITLE
Incorrect binary path with cargo install

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,26 @@ sudo usermod -aG input $USER
 
 Create a udev rule for proper device permissions:
 
+Ubuntu/Debian:
+
 ```bash
 sudo tee /etc/udev/rules.d/99-elgato-pedal.rules > /dev/null << 'EOF'
 # Elgato Stream Deck Pedal
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0086", MODE="0666", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0086", MODE="0666", GROUP="plugdev"
+EOF
+
+# Reload udev rules
+sudo udevadm control --reload-rules && sudo udevadm trigger
+```
+
+Arch/Fedora
+
+```bash
+sudo tee /etc/udev/rules.d/99-elgato-pedal.rules > /dev/null << 'EOF'
+# Elgato Stream Deck Pedal
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0086", MODE="0666", GROUP="input"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0fd9", ATTRS{idProduct}=="0086", MODE="0666", GROUP="input"
 EOF
 
 # Reload udev rules

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ EOF
 sudo udevadm control --reload-rules && sudo udevadm trigger
 ```
 
-Arch/Fedora
+Arch/Fedora:
 
 ```bash
 sudo tee /etc/udev/rules.d/99-elgato-pedal.rules > /dev/null << 'EOF'

--- a/src/hold_intent_parser.rs
+++ b/src/hold_intent_parser.rs
@@ -13,7 +13,7 @@ pub struct HoldIntentParser {
 }
 
 impl HoldIntentParser {
-    pub fn new(global_default_threshold_ms: u64) -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn new(global_default_threshold_ms: u64) -> anyhow::Result<Self> {
         let config_manager = ConfigManager::global();
         let config_parser = config_manager.get_parser();
         Ok(Self {
@@ -28,7 +28,7 @@ impl HoldIntentParser {
         data: &[u8],
         now: Instant,
         mut event_handler: F,
-    ) -> Result<(), Box<dyn std::error::Error>>
+    ) -> anyhow::Result<()>
     where
         F: FnMut(ButtonEvent),
     {
@@ -151,7 +151,7 @@ impl HoldIntentParser {
         &mut self,
         now: Instant,
         mut event_handler: F,
-    ) -> Result<(), Box<dyn std::error::Error>>
+    ) -> anyhow::Result<()>
     where
         F: FnMut(ButtonEvent),
     {

--- a/src/input_simulator.rs
+++ b/src/input_simulator.rs
@@ -124,7 +124,7 @@ impl InputSimulator {
                 }
                 ExecutableAction::Text { text } => {
                     self.execute_text(text.clone())
-                        .context(format!("Failed to execute text input for {}", text))?;
+                        .context("Failed to execute text input")?;
                 }
                 ExecutableAction::Sleep { duration_ms } => {
                     self.execute_sleep(*duration_ms)

--- a/src/input_simulator.rs
+++ b/src/input_simulator.rs
@@ -1,4 +1,5 @@
 use crate::token_based_config::ExecutableAction;
+use anyhow::{Context, Result};
 use enigo::Keyboard;
 use enigo::{
     Direction, Enigo, Key, Settings,
@@ -14,7 +15,7 @@ pub struct InputSimulator {
 }
 
 impl InputSimulator {
-    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn new() -> Result<Self> {
         println!("Initializing Input Simulation System");
         println!("{}", "=".repeat(80));
 
@@ -67,8 +68,7 @@ impl InputSimulator {
 
         println!("{}", "=".repeat(80));
 
-        let enigo = Enigo::new(&Settings::default())
-            .map_err(|e| format!("Failed to create Enigo instance: {}", e))?;
+        let enigo = Enigo::new(&Settings::default()).context("Failed to create Enigo instance.")?;
 
         let _test_token = Token::Key(Key::Escape, Direction::Press);
         println!("Input simulation system initialized successfully");
@@ -80,10 +80,7 @@ impl InputSimulator {
         })
     }
 
-    pub fn execute_actions(
-        &mut self,
-        actions: &[ExecutableAction],
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn execute_actions(&mut self, actions: &[ExecutableAction]) -> Result<()> {
         if actions.is_empty() {
             return Ok(());
         }
@@ -118,24 +115,20 @@ impl InputSimulator {
 
             match action {
                 ExecutableAction::KeyPress { key, auto_release } => {
-                    if let Err(e) = self.execute_key_press(*key, *auto_release) {
-                        return Err(format!("Failed to execute key press: {}", e).into());
-                    }
+                    self.execute_key_press(*key, *auto_release)
+                        .context(format!("Failed to execute key press"))?;
                 }
                 ExecutableAction::KeyRelease { key } => {
-                    if let Err(e) = self.execute_key_release(*key) {
-                        return Err(format!("Failed to execute key release: {}", e).into());
-                    }
+                    self.execute_key_release(*key)
+                        .context("Failed to execute key release")?;
                 }
                 ExecutableAction::Text { text } => {
-                    if let Err(e) = self.execute_text(text.clone()) {
-                        return Err(format!("Failed to execute text input: {}", e).into());
-                    }
+                    self.execute_text(text.clone())
+                        .context(format!("Failed to execute text input for {}", text))?;
                 }
                 ExecutableAction::Sleep { duration_ms } => {
-                    if let Err(e) = self.execute_sleep(*duration_ms) {
-                        return Err(format!("Failed to execute sleep: {}", e).into());
-                    }
+                    self.execute_sleep(*duration_ms)
+                        .context("Failed to execute sleep.")?;
                 }
                 ExecutableAction::ReleaseAfter { duration_ms } => {
                     self.schedule_release_all_after(*duration_ms);
@@ -157,69 +150,48 @@ impl InputSimulator {
         Ok(())
     }
 
-    fn execute_key_press(
-        &mut self,
-        key: Key,
-        auto_release: bool,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute_key_press(&mut self, key: Key, auto_release: bool) -> Result<()> {
         let press_token = Token::Key(key, Direction::Press);
 
-        match self.enigo.execute(&press_token) {
-            Ok(_) => {
-                self.pressed_keys.insert(key);
+        self.enigo
+            .execute(&press_token)
+            .context("Failed to execute key press.")?;
 
-                if auto_release {
-                    let release_token = Token::Key(key, Direction::Release);
-                    match self.enigo.execute(&release_token) {
-                        Ok(_) => {
-                            self.pressed_keys.remove(&key);
-                        }
-                        Err(e) => {
-                            eprintln!("Error: Failed to auto-release key {:?}: {}", key, e);
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                eprintln!("Error: Failed to press key {:?}: {}", key, e);
-                return Err(format!("Failed to execute key press: {e}").into());
-            }
+        self.pressed_keys.insert(key);
+
+        if auto_release {
+            let release_token = Token::Key(key, Direction::Release);
+            self.enigo
+                .execute(&release_token)
+                .context("Failed to auto-release key.")?;
+            self.pressed_keys.remove(&key);
         }
 
         Ok(())
     }
 
-    fn execute_key_release(&mut self, key: Key) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute_key_release(&mut self, key: Key) -> Result<()> {
         if self.pressed_keys.contains(&key) {
             let release_token = Token::Key(key, Direction::Release);
 
-            match self.enigo.execute(&release_token) {
-                Ok(_) => {
-                    self.pressed_keys.remove(&key);
-                }
-                Err(e) => {
-                    eprintln!("Error: Failed to release key {:?}: {}", key, e);
-                    return Err(format!("Failed to execute key release: {e}").into());
-                }
-            }
+            self.enigo
+                .execute(&release_token)
+                .context("Failed to execute key release.")?;
+
+            self.pressed_keys.remove(&key);
         }
 
         Ok(())
     }
 
-    fn execute_text(&mut self, text: String) -> Result<(), Box<dyn std::error::Error>> {
-        match self.enigo.text(&text) {
-            Ok(_) => {}
-            Err(e) => {
-                eprintln!("Error: Failed to execute text input: {}", e);
-                return Err(format!("Failed to execute text: {e}").into());
-            }
-        }
-
+    fn execute_text(&mut self, text: String) -> Result<()> {
+        self.enigo
+            .text(&text)
+            .context("Failed to execute text input.")?;
         Ok(())
     }
 
-    fn execute_sleep(&self, duration_ms: u64) -> Result<(), Box<dyn std::error::Error>> {
+    fn execute_sleep(&self, duration_ms: u64) -> Result<()> {
         std::thread::sleep(Duration::from_millis(duration_ms));
         Ok(())
     }
@@ -244,7 +216,7 @@ impl InputSimulator {
         }
     }
 
-    pub fn process_scheduled_releases(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn process_scheduled_releases(&mut self) -> Result<()> {
         let now = Instant::now();
         let mut releases_to_process = Vec::new();
 

--- a/src/input_simulator.rs
+++ b/src/input_simulator.rs
@@ -116,7 +116,7 @@ impl InputSimulator {
             match action {
                 ExecutableAction::KeyPress { key, auto_release } => {
                     self.execute_key_press(*key, *auto_release)
-                        .context(format!("Failed to execute key press"))?;
+                        .context(format!("Failed to execute key press for {:?}", key))?;
                 }
                 ExecutableAction::KeyRelease { key } => {
                     self.execute_key_release(*key)

--- a/src/service_manager.rs
+++ b/src/service_manager.rs
@@ -95,7 +95,7 @@ impl ServiceManager {
             None => {
                 let searched: String = paths
                     .iter()
-                    .map(|p| format!("\n\t {}", p.display()))
+                    .map(|p| format!("\n         {}", p.display()))
                     .collect::<Vec<_>>()
                     .join("");
 


### PR DESCRIPTION
This PR introduces changes that fixes #2: install errors when installing using the `cargo install` method.

## README.md updates ##
Updated the udev rules section so  that it matches the arch linux usermod group change. The existing udev rule used the group `plugdev` when the arch linux usermod line uses `input` as the group. This change adds a section that aligns the arch groups.

## cargo binary path ##
Updated the `get_binary_path` function to check both the `$HOME/.local/bin` and `$HOME/.cargo/bin` folders for the `elgato-pedal-controller` binary. It will return the first location it finds where the binary exists OR return the error that it cannot find the binary.

The error when it doesn't find the binary has been updated to show the seached locations:

```bash
Installing Elgato Pedal Controller as systemd service...
❌ Failed to install service: Failed to get binary path:
Binary not found at:
         /home/matt/.local/bin/elgato-pedal-controller
         /home/matt/.cargo/bin/elgato-pedal-controller
Please run 'make install' first.
```

