### PR TITLE
Reconnect enigo on broken pipe error

### DIFF
--- a/src/hold_intent_input_action_manager.rs
+++ b/src/hold_intent_input_action_manager.rs
@@ -130,9 +130,9 @@ impl HoldIntentInputActionManager {
                 Ok(_) => {}
                 Err(e) => {
                     eprintln!("Failed to execute actions: {e}");
-                    if format!("{e:?}").contains("Wayland")
-                        || format!("{e:?}").contains("Broken Pipe")
-                    {
+                    let error = e.to_string();
+
+                    if error.contains("Wayland") || error.contains("Broken pipe") {
                         eprintln!(
                             "Warning: Wayland connection lost during action execution. Recreating backend."
                         );

--- a/src/hold_intent_input_action_manager.rs
+++ b/src/hold_intent_input_action_manager.rs
@@ -128,7 +128,19 @@ impl HoldIntentInputActionManager {
 
             match self.input_simulator.execute_actions(&actions) {
                 Ok(_) => {}
-                Err(e) => eprintln!("Failed to execute actions: {e}"),
+                Err(e) => {
+                    eprintln!("Failed to execute actions: {e}");
+                    if format!("{e:?}").contains("Wayland")
+                        || format!("{e:?}").contains("Broken Pipe")
+                    {
+                        eprintln!(
+                            "Warning: Wayland connection lost during action execution. Recreating backend."
+                        );
+
+                        self.input_simulator.reconnect()?;
+                        self.input_simulator.execute_actions(&actions)?;
+                    }
+                }
             }
         } else {
             println!(

--- a/src/input_simulator.rs
+++ b/src/input_simulator.rs
@@ -80,6 +80,12 @@ impl InputSimulator {
         })
     }
 
+    pub fn reconnect(&mut self) -> Result<()> {
+        let enigo = Enigo::new(&Settings::default()).context("Failed to create Enigo instance.")?;
+        self.enigo = enigo;
+        Ok(())
+    }
+
     pub fn execute_actions(&mut self, actions: &[ExecutableAction]) -> Result<()> {
         if actions.is_empty() {
             return Ok(());


### PR DESCRIPTION
Hello again,

I've been getting this intermittent issue on Arch+Sway where the keys would stop working. The logs show only this error:
```
Mar 10 08:35:57.474285 magenta elgato-pedal-controller[117397]: ------------------------------------------------------------
Mar 10 08:35:57.474285 magenta elgato-pedal-controller[117397]: | 1   | Release All Keys                                   |
Mar 10 08:35:57.474285 magenta elgato-pedal-controller[117397]: Scheduled 1 keys for delayed release (0ms)
Mar 10 08:35:57.484246 magenta elgato-pedal-controller[117397]: ------------------------------------------------------------
Mar 10 08:35:57.484246 magenta elgato-pedal-controller[117397]: Action sequence completed successfully
Mar 10 08:35:57.626807 magenta elgato-pedal-controller[117397]: Io error: Broken pipe (os error 32)
Mar 10 08:35:57.626894 magenta elgato-pedal-controller[117397]: Error: Failed to execute scheduled release for F6: simulating input failed: (could not flush Wayland queue)
Mar 10 08:36:09.008627 magenta elgato-pedal-controller[117397]: Received 8 bytes from HID device: [1, 0, 3, 0, 0, 0, 1, 0]
Mar 10 08:36:09.008627 magenta elgato-pedal-controller[117397]: 🔍 Parsing HID data: [1, 0, 3, 0, 0, 0, 1, 0]
Mar 10 08:36:09.008627 magenta elgato-pedal-controller[117397]: 🔄 Button button_2 state transition: RELEASED -> PRESSED
Mar 10 08:36:09.008627 magenta elgato-pedal-controller[117397]: 🔍 Extracted button states: [(Button2, true)]
```

Notice the `Broken Pipe` error and the `could not flush Wayland queue`. The second error comes from the (enigo flush code)[https://github.com/enigo-rs/enigo/blob/6f311ea173fef3a4eb75909903697226582f657f/src/linux/wayland.rs#L268].

Although I am currently unsure of what causes the broken pipe, I added a workaround until I or someone else has time to dig deeper.

The work around is: 
1. Call `execute_actions` returns error
2. check the execute action error for `Wayland` or `Broken Pipe` 
3. "reconnect" enigo by creating a new instance
4. call `execute_actions` again or fail on error.

So far this has rectified the issue and saves me from having to restart the service.

If you have any ideas on what would cause the Broken Pipe error (GPT seems to think it might be a stale SOCK file or something), please let me know. My knowledge of the inner working of wayland is limited.